### PR TITLE
Enhance: Add an debug message on build (gatsby-node.js)

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require(`path`);
+const report = require(`gatsby-cli/lib/reporter`);
 require('dotenv').config();
 const config = require('./gatsby-config');
 
@@ -22,6 +23,10 @@ exports.createPages = async ({ graphql, actions }) => {
     `,
     { filter: postsFilter }
   );
+  if (!data || !data.fireblog.postsCount) {
+    report.error(`Fireblog: no posts found for blog ${process.env.GATSBY_BLOG_ID} check your env file configuration !`)
+    return
+  }
   const postsCount = data.fireblog.postsCount;
 
   let limit = config.siteMetadata.postsPerPage;


### PR DESCRIPTION
Debugging env file issues is not simple :
- with wrong `GATSBY_FIREBLOG_GRAPHQL_ENDPOINT` we got plenty of errors
- and with bad `GATSBY_BLOG_ID` that result in an empty site (only 404 page)

This PR aim to add a little more debug information for those cases.

![image](https://user-images.githubusercontent.com/6529851/95213055-ad894f00-07ee-11eb-94c4-e4794fa9e12f.png)
